### PR TITLE
fix: configuration based on enketo monorepo

### DIFF
--- a/benchmark
+++ b/benchmark
@@ -3,10 +3,10 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 const program = require( 'commander' );
-const transformer = require( '../enketo-core/node_modules/enketo-transformer' );
+const config = require( './config.json' );
+const transformer = require( '../enketo/node_modules/enketo-transformer' );
 const puppeteer = require( 'puppeteer' );
 const graphite = require( 'graphite' );
-const config = require( './config.json' );
 const client = graphite.createClient( `plaintext://${config[ 'graphite url' ]}` );
 const pkg = require( './package.json' );
 

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
     "graphite url": "127.0.0.1:2003",
     "data prefix": "core",
-    "enketo core path": "../enketo-core"
+    "enketo core path": "../enketo/packages/enketo-core"
 }


### PR DESCRIPTION
Structure of Enketo has changed since it turned into a mono-repo with different packages, so this setup needs to be adjusted to fit the new structure of Enketo's repository.